### PR TITLE
adds injectable implementation of partitioning memory cache

### DIFF
--- a/src/Extensions.Caching.Extras/Extensions.Caching.Extras.csproj
+++ b/src/Extensions.Caching.Extras/Extensions.Caching.Extras.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="MinVer" Version="2.3.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Extensions.Caching.Extras/MemoryCachePartitionOfT.cs
+++ b/src/Extensions.Caching.Extras/MemoryCachePartitionOfT.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Extensions.Caching.Extras
+{
+    /// <summary>
+    /// A partition over an <see cref="IMemoryCache"/> for a specific typed partition.
+    /// </summary>
+    /// <typeparam name="TPartition">The type of the partition.</typeparam>
+    public interface IMemoryCachePartition<TPartition> : IMemoryCache
+    {
+    }
+
+    /// <summary>
+    /// A partition over an <see cref="IMemoryCache"/> for a specific typed partition.
+    /// </summary>
+    /// <typeparam name="TPartition">The type of the partition.</typeparam>
+    public class MemoryCachePartition<TPartition> : IMemoryCachePartition<TPartition>
+    {
+        private readonly IMemoryCache _cache;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MemoryCachePartition{TPartition}"/>.
+        /// </summary>
+        /// <param name="cache">The cache over which to create a partition.</param>
+        public MemoryCachePartition(IMemoryCache cache)
+        {
+            if (cache == null)
+                throw new ArgumentNullException(nameof(cache));
+
+            _cache = new MemoryCachePartition(cache, typeof(TPartition));
+        }
+
+        /// <inheritdoc />
+        public void Dispose() => _cache.Dispose();
+
+        /// <inheritdoc />
+        public bool TryGetValue(object key, out object value) => _cache.TryGetValue(key, out value);
+
+        /// <inheritdoc />
+        public ICacheEntry CreateEntry(object key) => _cache.CreateEntry(key);
+
+        /// <inheritdoc />
+        public void Remove(object key) => _cache.Remove(key);
+    }
+}

--- a/src/Extensions.Caching.Extras/Microsoft.Extensions.Caching.Memory/MemoryCacheExtensions.cs
+++ b/src/Extensions.Caching.Extras/Microsoft.Extensions.Caching.Memory/MemoryCacheExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Extensions.Caching.Extras;
 
+// ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.Caching.Memory
 {
     /// <summary>

--- a/src/Extensions.Caching.Extras/Microsoft.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Extensions.Caching.Extras/Microsoft.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Extensions.Caching.Extras;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Provides methods to extend the behavior of <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds <see cref="IMemoryCachePartition{TPartition}"/> to the service collection.
+        /// </summary>
+        /// <param name="services">The <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection" /> to add the service to.</param>
+        /// <returns>A reference to this instance after the operation has completed.</returns>
+        public static IServiceCollection AddMemoryCachePartitions(this IServiceCollection services)
+        {
+            services.AddTransient(typeof(IMemoryCachePartition<>), typeof(MemoryCachePartition<>));
+            return services;
+        }
+    }
+}

--- a/tests/Extensions.Caching.Extras.Tests/DependencyInjectionTests.cs
+++ b/tests/Extensions.Caching.Extras.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Extensions.Caching.Extras.Tests
+{
+    public class DependencyInjectionTests
+    {
+        [Fact]
+        public void Can_inject_IPartitionedMemoryCache()
+        {
+            var services = new ServiceCollection();
+            services.AddMemoryCache();
+            services.AddMemoryCachePartitions();
+            services.AddTransient<TestService>();
+            var serviceProvider = services.BuildServiceProvider();
+
+            var testService = serviceProvider.GetService<TestService>();
+
+            testService.CachePartition.Should().BeOfType<MemoryCachePartition<TestService>>();
+
+            testService.CachePartition.Set("key", "value");
+
+            var cacheValue = serviceProvider.GetService<IMemoryCache>().Partition<TestService>().Get("key");
+
+            cacheValue.Should().BeOfType<string>().Which.Should().Be("value");
+        }
+
+        public class TestService
+        {
+            public TestService(IMemoryCachePartition<TestService> cachePartition)
+            {
+                CachePartition = cachePartition;
+            }
+
+            public IMemoryCachePartition<TestService> CachePartition { get; private set; }
+        }
+    }
+}

--- a/tests/Extensions.Caching.Extras.Tests/Extensions.Caching.Extras.Tests.csproj
+++ b/tests/Extensions.Caching.Extras.Tests/Extensions.Caching.Extras.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a partitioning memory cache for dependency injection by using a factory pattern with open generics.

E.g. if `TestService` requires its own partition of `IMemoryCache`, you can inject an instance of `IMemoryCachePartition<TestService>`:

```csharp
public class TestService
{
    private readonly IMemoryCache _cache;

    public TestService(IMemoryCachePartition<TestService> cachePartition)
    {
        _cache = cachePartition;
    }
}
```

My code registers `IMemoryCachePartition<>` as transient, but it could be changed to singleton.

Please note that this PR adds a dependency on `Microsoft.Extensions.DependencyInjection.Abstractions`.

What do you think about this addition?